### PR TITLE
Use shared array buffers to also send the pluck messages between threads

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,10 +60,10 @@
                     </div>
                 </section>
                 <section>
-                    <h4 style="margin-bottom: 5px">Audio->GUI channel</h4>
-                    <p style="font-size: 0.7em; color: #999">There are two options for sending data from the audio rendering thread to the GUI/main thread: 
+                    <h4 style="margin-bottom: 5px">Communication channel</h4>
+                    <p style="font-size: 0.7em; color: #999">There are two options for sending data between the audio rendering thread and the GUI (main) thread: 
                     MessagePort (which creates garbage) or using SharedArrayBuffers (which do not necessarily create garbage). When SharedArrayBuffer is selected, this page is 
-                    using <a href="https://github.com/padenot/ringbuf.js">Paul Adenot's lock-free data structures library.</a></p>
+                    using <a href="https://github.com/padenot/ringbuf.js">Paul Adenot's lock-free queue library.</a></p>
                     <div>
                         <input type="radio" id="choice-port" name="channel" value="port" onchange="changeChannel('port')" />
                         <label style="font-size: 0.8em;" for="choice-port">MessagePort</label>
@@ -153,15 +153,29 @@
                             node.port.onmessage = handleStringMessage.bind(this, j);
                         }
                         else if (window.communicationChannel === "sab") {
-                            let sharedBuffer = RingBuffer.getStorageForCapacity(32 * 100, Uint8Array);
-                            let ringBuffer = new RingBuffer(sharedBuffer, Uint8Array);
-                            let paramReader = new ParameterReader(ringBuffer);
-                            node.port.postMessage({
-                                type: "shared-buffer",
-                                buffer: sharedBuffer,
-                            });
+                            {
+                                let sharedBuffer = RingBuffer.getStorageForCapacity(32 * 100, Uint8Array);
+                                let ringBuffer = new RingBuffer(sharedBuffer, Uint8Array);
+                                let paramReader = new ParameterReader(ringBuffer);
+                                node.port.postMessage({
+                                    type: "shared-buffer",
+                                    buffer: sharedBuffer,
+                                });
 
-                            node.paramReader = paramReader;
+                                node.paramReader = paramReader;
+                            }
+
+                            {
+                                let sharedBuffer = RingBuffer.getStorageForCapacity(31, Uint8Array);
+                                let ringBuffer = new RingBuffer(sharedBuffer, Uint8Array);
+                                let paramWriter = new ParameterWriter(ringBuffer);
+                                node.port.postMessage({
+                                    type: "shared-buffer-plucks",
+                                    buffer: sharedBuffer,
+                                })
+
+                                node.paramWriter = paramWriter;
+                            }
                         }
 
                         audioNodes.push(node);
@@ -291,7 +305,11 @@
         
         const pluckString = (i) => {
             const nodeIndex = stringIndexToNodeIndex(i);
-            audioNodes[nodeIndex].port.postMessage({type: "play", stringIndex: i % window.ratio});
+            if (window.communicationChannel === "port") {
+                audioNodes[nodeIndex].port.postMessage({type: "play", stringIndex: i % window.ratio});
+            } else if (window.communicationChannel === "sab") {
+                audioNodes[nodeIndex].paramWriter.enqueue_change(i % window.ratio, true);
+            }
         }
 
         const strum = () => {

--- a/string-processor.js
+++ b/string-processor.js
@@ -19,7 +19,7 @@ class StringProcessor extends AudioWorkletProcessor {
 
     constructor(options) {
       super();
-      console.log("version 1");
+      console.log("version 2");
 
       // In order to be able to measure the overhead of each AudioWorkletNode,
       // this processor is written so that it can model an arbitrary number of
@@ -87,11 +87,21 @@ class StringProcessor extends AudioWorkletProcessor {
       else if (event.data.type === "shared-buffer") {
         this.parameterWriter = new ParameterWriter(new RingBuffer(event.data.buffer, Uint8Array));
       }
+      else if (event.data.type === "shared-buffer-plucks") {
+        this.parameterReader = new ParameterReader(new RingBuffer(event.data.buffer, Uint8Array));
+      }
     }
 
     process(inputs, outputs, parameters) {
       const output = outputs[0];
       const outputChannel = output[0];
+
+      if (this.parameterReader) {
+        let o = { index: 0, value: 0 };
+        while (this.parameterReader.dequeue_change(o)) {
+          this.excitationReadIndices[o.index] = 0;
+        }
+      }
 
       if (output.length > 1) { throw new Error("This processor only expects mono"); }
 


### PR DESCRIPTION
To really rule out any clicks that might come as a result of GC due to PostMessage allocations.